### PR TITLE
Add missing rewrite rule for admin portal in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,10 @@
       "destination": "https://edukia-server.vercel.app/"
     },
     {
+      "source": "/admin-portal/",
+      "destination": "https://edukia-server.vercel.app/"
+    },
+    {
       "source": "/admin-portal/:path*",
       "destination": "https://edukia-server.vercel.app/:path*"
     },


### PR DESCRIPTION
Include a rewrite rule for the admin portal to handle trailing slashes correctly.